### PR TITLE
count() uses all(), not collection, as it's useful to override all() in certain circumstances

### DIFF
--- a/src/model_class_methods.js
+++ b/src/model_class_methods.js
@@ -24,7 +24,7 @@ Model.ClassMethods = {
   },
 
   count: function() {
-    return this.collection.length;
+    return this.all().length;
   },
 
   detect: function(func) {


### PR DESCRIPTION
fish ham eggs dogs cheese figs
