### PR TITLE
Test for custom REST code + example of single resource

### DIFF
--- a/test/tests/model_rest_test.js
+++ b/test/tests/model_rest_test.js
@@ -123,6 +123,37 @@ test("update with custom unique_key field", function() {
   server.respond()
 });
 
+test("update single resource", 3, function() {
+  var User = Model("user", function() {
+    this.use(Model.REST, "/user", {
+      update_path: function () {
+        return this.read_path()
+      }
+    })
+  });
+  var user = new User({ 'id': 1, email: "bob@example.com" });
+
+  this.spy(jQuery, "ajax")
+
+  var server = this.sandbox.useFakeServer()
+  server.respondWith("PUT", "/user", [200, {
+    "Content-Type": "application/json"
+  }, JSON.stringify({
+    id: 1, email: "bob@example.com"
+  })])
+
+  user.save(function(success) {
+    ok(success, "save() wasn't successful");
+  });
+
+  ok(jQuery.ajax.calledOnce)
+  deepEqual(JSON.parse(jQuery.ajax.getCall(0).args[0].data), {
+    user: { email: "bob@example.com" }
+  })
+
+  server.respond()
+})
+
 test("destroy with named params in resource path", function() {
   var Post = Model("post", function() {
     this.use(Model.REST, "/root/:root_id/nested/:nested_id/posts")


### PR DESCRIPTION
I was wondering how to make update() work with single resources (eg: /user as opposed to /users/343).

I realised I could use the `methods` parameter to the constructor of the REST class to do this. However, I noticed that this feature was not tested. Is it supposed to be used by the general public? Or is it "private"-ish? Is a test in order? Is this the way to accomplish my original goal?
