### PR TITLE
Slice the events array before looping through it

### DIFF
--- a/src/event_emitter.js
+++ b/src/event_emitter.js
@@ -33,7 +33,7 @@
 
   EventEmitter.prototype.emit = function(name) {
     var args = Array.prototype.slice.call(arguments, 1)
-    var events = prepareEvent.call(this, name)
+    var events = prepareEvent.call(this, name).slice()
 
     for (var i = 0, length = events.length; i < length; i++) {
       var callback = events[i].callback

--- a/test/tests/event_emitter_test.js
+++ b/test/tests/event_emitter_test.js
@@ -50,3 +50,21 @@ test("unbinding by callback and scope", 1, function() {
 
   ee.emit("a")
 })
+
+test("emitting events with callbacks that unbind events", function () {
+  var ee = new Model.EventEmitter,
+      eventName = 'test',
+      callbackCalled = false
+
+  var handler = function () {
+    ee.off(eventName, arguments.callee)
+  }
+
+  ee.on('test', handler)
+  ee.on('test', function () { callbackCalled = true })
+
+  ee.emit('test')
+
+  ok(callbackCalled)
+
+})


### PR DESCRIPTION
This fixes a bug where event handlers that mutate the events array cause index out of bounds errors.
