### PR TITLE
Yield the Model to the sortBy callback

### DIFF
--- a/src/collection.js
+++ b/src/collection.js
@@ -120,7 +120,7 @@
   Collection.prototype.sortBy = function(attribute_or_func) {
     var is_func = Model.Utils.isFunction(attribute_or_func)
     var extract = function(model) {
-      return attribute_or_func.call(model)
+      return attribute_or_func.call(model, model)
     }
 
     return this.sort(function(a, b) {

--- a/src/collection.js
+++ b/src/collection.js
@@ -118,14 +118,21 @@
   }
 
   Collection.prototype.sortBy = function(attribute_or_func) {
-    var is_func = Model.Utils.isFunction(attribute_or_func)
-    var extract = function(model) {
-      return attribute_or_func.call(model, model)
+    var comparator
+
+    if(Model.Utils.isFunction(attribute_or_func)) {
+      comparator = function(model) {
+        return attribute_or_func.call(model, model)
+      }
+    } else {
+      comparator = function(model) {
+        return model.get(attribute_or_func)
+      }
     }
 
     return this.sort(function(a, b) {
-      var a_attr = is_func ? extract(a) : a.get(attribute_or_func)
-      var b_attr = is_func ? extract(b) : b.get(attribute_or_func)
+      var a_attr = comparator(a)
+      var b_attr = comparator(b)
 
       if (a_attr < b_attr) {
         return -1

--- a/src/collection.js
+++ b/src/collection.js
@@ -121,9 +121,7 @@
     var comparator
 
     if(Model.Utils.isFunction(attribute_or_func)) {
-      comparator = function(model) {
-        return attribute_or_func.call(model, model)
-      }
+      comparator = attribute_or_func
     } else {
       comparator = function(model) {
         return model.get(attribute_or_func)

--- a/test/tests/collection_test.js
+++ b/test/tests/collection_test.js
@@ -112,15 +112,6 @@ test("#sort, #sortBy", function() {
   ok(sorted.at(1) === b)
   ok(sorted.at(2) === c)
 
-  sorted = collection.sortBy(function() {
-    return this.get("title")
-  })
-
-  ok(sorted instanceof Model.Collection, "returns another Collection")
-  ok(sorted.at(0) === a)
-  ok(sorted.at(1) === b)
-  ok(sorted.at(2) === c)
-
   sorted = collection.sortBy(function(post) {
     return post.get("title")
   })

--- a/test/tests/collection_test.js
+++ b/test/tests/collection_test.js
@@ -111,6 +111,24 @@ test("#sort, #sortBy", function() {
   ok(sorted.at(0) === a)
   ok(sorted.at(1) === b)
   ok(sorted.at(2) === c)
+
+  sorted = collection.sortBy(function() {
+    return this.get("title")
+  })
+
+  ok(sorted instanceof Model.Collection, "returns another Collection")
+  ok(sorted.at(0) === a)
+  ok(sorted.at(1) === b)
+  ok(sorted.at(2) === c)
+
+  sorted = collection.sortBy(function(post) {
+    return post.get("title")
+  })
+
+  ok(sorted instanceof Model.Collection, "returns another Collection")
+  ok(sorted.at(0) === a)
+  ok(sorted.at(1) === b)
+  ok(sorted.at(2) === c)
 })
 
 test("#detect", function() {


### PR DESCRIPTION
As per the documentation in the v1-docs branch. The makes it consistent with the other collection methods.

I think ideally this shouldn't change the value of `this`, but that would be a breaking change.
